### PR TITLE
Implement SSH string notification via http://ix.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: valeriangalliat/action-sshd-cloudflared@v1
+      - uses: valeriangalliat/action-sshd-cloudflared@v2
 ```
 
 Example output:
@@ -79,6 +79,44 @@ When logging in, you'll be automatically attached to a tmux session.
 Whenever you exit the session, the action will stop the tunnel and SSH
 server and continue its steps.
 
+## Getting SSH connection string via http://ix.io
+
+If you invoke this action via `dispatch_workflow`, you have no chance to
+get the SSH connection from Github user interface. This is annoying, and
+the solution for it is easy: to use the pastebin service like http://ix.io
+
+Why IX?
+
+- It is free
+- It supports creating named users with password on-the-fly, and provides
+the per-user paste list available at `http://ix.io/user/USERNAME`
+- All interactions can be done via simple `curl` requests
+
+To get SSH connection string via IX, first generate random (or meaningful)
+user name and password and add them as `IX_USERNAME` and `IX_PASSWORD` Github
+project secrets. Next, add the environment variables to the action YAML file
+as follows:
+
+```yaml
+name: CI
+on:
+  - push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: valeriangalliat/action-sshd-cloudflared@v2
+        env:
+          - IX_USERNAME: ${{ secrets.IX_USERNAME }}
+          - IX_PASSWORD: ${{ secrets.IX_PASSWORD }}
+```
+
+When workflow is started, navigate to `http://ix.io/user/<IX_USERNAME>` and
+grab your SSH connection details!
+
+Please note the paste is automatically deleted on workflow completion.
+
 ## More details
 
 If you want to know everything about this program, you can read the
@@ -108,6 +146,10 @@ like the SSH host.
 
 This is more likely to happen if this is one of the first actions in
 your workflow.
+
+The preferred solution for such behavior is to use IX notification (see above),
+but if you don't want to go with external services, please read the old workarounds
+below:
 
 At that point you need to cancel the action and restart it, making sure
 to open the logs right away, and reload the page aggressively in the

--- a/setup-ssh
+++ b/setup-ssh
@@ -28,6 +28,18 @@ fi
 
 # Start of script
 
+# Check non-coreutils dependencies
+
+EXTERNAL_DEPS="curl jq ssh-keygen"
+
+for EXTERNAL_DEP in $EXTERNAL_DEPS
+do
+    if ! command -v "$EXTERNAL_DEP" 1>/dev/null 2>&1; then
+       echo "Command $EXTERNAL_DEP not installed on the system!" >&2
+       exit 1
+    fi
+done
+
 cd "$GITHUB_ACTION_PATH"
 
 cloudflared_url=https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64

--- a/setup-ssh
+++ b/setup-ssh
@@ -7,7 +7,26 @@
 # - `GITHUB_ACTION_PATH`: path to this repository.
 # - `GITHUB_ACTOR`: GitHub username of whoever triggered the action.
 # - `GITHUB_WORKSPACE`: default path for the workflow (the tmux session will start there).
+# - `IX_USERNAME`: (optional) The username on http://ix.io where SSH connection string will be dropped
+# - `IX_PASSWORD`: (optional) The password on http://ix.io
 #
+
+# ix.io notification routine: save the URL of the paste in /tmp/ix-io.txt so we can delete
+# the paste from the ix.io server on session end
+
+notify_func()
+{
+    tee /dev/null
+}
+
+if [ ! -z "$IX_USERNAME" ] && [ ! -z "$IX_PASSWORD" ]; then
+notify_func()
+{
+    tee >(curl -u "$IX_USERNAME:$IX_PASSWORD" -F 'f:1=<-' http://ix.io 1>/tmp/ix-io.txt)
+}
+fi
+
+# Start of script
 
 cd "$GITHUB_ACTION_PATH"
 
@@ -85,50 +104,54 @@ url=$(head -1 <(tail -f cloudflared.log | grep --line-buffered -o 'https://.*\.t
 # Ignore the `user@host` part at the end of the public key
 public_key=$(cut -d' ' -f1,2 < ssh_host_rsa_key.pub)
 
-# Echo spaces on empty lines because if we just echo a newline, GitHub will eat it
-echo '    '
-echo '    '
-echo '    '
-echo '    '
-echo 'Run the following command to connect:'
-echo '    '
-echo "    ssh-keygen -R action-sshd-cloudflared && echo 'action-sshd-cloudflared $public_key' >> ~/.ssh/known_hosts && ssh -o ProxyCommand='cloudflared access tcp --hostname $url' runner@action-sshd-cloudflared"
+# Notify the actor and output to the run log
 
-#
-# Unlike Upterm that runs a custom SSH server to accept passwords in the
-# username field with the `:password` syntax, standard `sshd` doesn't
-# accept that, so we need to paste the password like mere mortals.
-#
-if [ -n "$password" ]; then
+(
+    # Echo spaces on empty lines because if we just echo a newline, GitHub will eat it
     echo '    '
-    echo "    # Password: $password"
-fi
+    echo '    '
+    echo '    '
+    echo '    '
+    echo 'Run the following command to connect:'
+    echo '    '
+    echo "    ssh-keygen -R action-sshd-cloudflared && echo 'action-sshd-cloudflared $public_key' >> ~/.ssh/known_hosts && ssh -o ProxyCommand='cloudflared access tcp --hostname $url' runner@action-sshd-cloudflared"
 
-#
-# You might notice we use `action-sshd-cloudflared` as a SSH host to connect.
-# This is abritrary and we could put anything here, because of the
-# `ProxyCommand` option later, the host is ignored and we directly go through
-# the tunnel exposed by `cloudflared`. But for the `ssh` command to be valid,
-# we still need to give it a host.
-#
-echo '    '
-echo "What the one-liner does:"
-echo '    '
-echo '    # Remove old SSH server public key for `action-sshd-cloudflared`'
-echo "    ssh-keygen -R action-sshd-cloudflared"
-echo '    '
-echo '    # Trust the public key for this session'
-echo "    echo 'action-sshd-cloudflared $public_key' >> ~/.ssh/known_hosts"
-echo '    '
-echo '    # Connect using `cloudflared` as a transport (SSH is end-to-end encrpted over this tunnel)'
-echo "    ssh -o ProxyCommand='cloudflared access tcp --hostname $url' runner@action-sshd-cloudflared"
-echo '    '
-echo "    # Alternative if you don't want to verify the host key"
-echo "    ssh -o ProxyCommand='cloudflared access tcp --hostname $url' -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=accept-new runner@action-sshd-cloudflared"
-echo '    '
-echo '    '
-echo '    '
-echo '    '
+    #
+    # Unlike Upterm that runs a custom SSH server to accept passwords in the
+    # username field with the `:password` syntax, standard `sshd` doesn't
+    # accept that, so we need to paste the password like mere mortals.
+    #
+    if [ -n "$password" ]; then
+        echo '    '
+        echo "    # Password: $password"
+    fi
+
+    #
+    # You might notice we use `action-sshd-cloudflared` as a SSH host to connect.
+    # This is abritrary and we could put anything here, because of the
+    # `ProxyCommand` option later, the host is ignored and we directly go through
+    # the tunnel exposed by `cloudflared`. But for the `ssh` command to be valid,
+    # we still need to give it a host.
+    #
+    echo '    '
+    echo "What the one-liner does:"
+    echo '    '
+    echo '    # Remove old SSH server public key for `action-sshd-cloudflared`'
+    echo "    ssh-keygen -R action-sshd-cloudflared"
+    echo '    '
+    echo '    # Trust the public key for this session'
+    echo "    echo 'action-sshd-cloudflared $public_key' >> ~/.ssh/known_hosts"
+    echo '    '
+    echo '    # Connect using `cloudflared` as a transport (SSH is end-to-end encrpted over this tunnel)'
+    echo "    ssh -o ProxyCommand='cloudflared access tcp --hostname $url' runner@action-sshd-cloudflared"
+    echo '    '
+    echo "    # Alternative if you don't want to verify the host key"
+    echo "    ssh -o ProxyCommand='cloudflared access tcp --hostname $url' -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=accept-new runner@action-sshd-cloudflared"
+    echo '    '
+    echo '    '
+    echo '    '
+    echo '    '
+) | notify_func
 
 #
 # The `channel` argument is not used but needs to be passed.
@@ -143,3 +166,7 @@ echo 'Session ended'
 
 kill "$cloudflared_pid"
 kill "$sshd_pid"
+
+if [ -s /tmp/ix-io.txt ]; then
+    curl -u "$IX_USERNAME:$IX_PASSWORD" -X DELETE "$(cat /tmp/ix-io.txt)"
+fi


### PR DESCRIPTION
Resolve the inability to get SSH connection string by implementing http://ix.io integration. This likely needs a version bump, so I adjusted the README.md to reference `v2` tag.
