### PR TITLE
Allow custom SSH command

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,4 @@
+# If we're in an interactive SSH session and we're not already in tmux and there's no explicit SSH command, auto attach tmux
+if [ -n "$SSH_TTY" ] && [ -z "$TMUX" ] && [ -z "$SSH_ORIGINAL_COMMAND" ]; then
+    exec tmux attach || exec tmux
+fi

--- a/setup-ssh
+++ b/setup-ssh
@@ -38,6 +38,24 @@ done
 
 cd "$GITHUB_ACTION_PATH"
 
+bashrc_path=$(pwd)/bashrc
+
+#
+# Source our `bashrc` to auto start tmux upon SSH login.
+#
+# Added to `~/.bash_profile` because at least on GitHub default runner, there's
+# both a `~/.bash_profile` that sets up `nvm`, and a `~/.profile` that sources
+# `~/.bashrc` if interactive, but Bash will only source `~/.bash_profile` if it
+# exists, so in a GitHub runner, `~/.bashrc` will never be sourced when using a
+# login shell like over SSH (but it will if starting a sub non-login shell by
+# typing `bash`).
+#
+# So we hook into `~/.bash_profile` instead.
+#
+if ! grep -q "$bashrc_path" ~/.bash_profile; then
+    echo "source \"$bashrc_path\"" >> ~/.bash_profile
+fi
+
 cloudflared_url=https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
 echo "Downloading \`cloudflared\` from <$cloudflared_url>..."
 curl --location --silent --output cloudflared "$cloudflared_url"

--- a/sshd_config.template
+++ b/sshd_config.template
@@ -20,7 +20,4 @@ AllowUsers $USER
 # Only allow those keys
 AuthorizedKeysFile $PWD/authorized_keys
 
-# Force to start tmux on login
-ForceCommand tmux attach
-
 # vim: ft=sshdconfig


### PR DESCRIPTION
By using `ForceCommand tmux attach`, we're preventing `ssh runner@host some command`

It's useful to run commands like this e.g. to download files from the runner

This PR removes the `ForceCommand` and instead hooks into `~/.bash_profile` to auto attach tmux upon interactive login